### PR TITLE
add story data, add name field, tweak reset logic to clear stored name

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,75 +1,101 @@
-import { useState } from 'react'
-import ThemeToggle from './components/ThemeToggle'
-import { SettingsMenu } from './components/SettingsMenu'
-import { Button } from './components/ui/Button'
-import StoryRenderer from './components/StoryRenderer'
-import { useStoryStore } from './store/storyStore'
-import MenuAudioLoop from './components/MenuAudioLoop'
+import { useState } from "react";
+import ThemeToggle from "./components/ThemeToggle";
+import { SettingsMenu } from "./components/SettingsMenu";
+import { Button } from "./components/ui/Button";
+import StoryRenderer from "./components/StoryRenderer";
+import { useStoryStore } from "./store/storyStore";
+import MenuAudioLoop from "./components/MenuAudioLoop";
 
 function App() {
-  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
-  const { currentNode, visited, reset, soundEnabled, setSoundEnabled } = useStoryStore()
-  const visitedCount = visited.length
-  const toggleSound = () => setSoundEnabled(!soundEnabled)
+    const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+    const {
+        currentNode,
+        visited,
+        reset,
+        soundEnabled,
+        setSoundEnabled,
+        setPlayerName,
+    } = useStoryStore();
+    const visitedCount = visited.length;
+    const toggleSound = () => setSoundEnabled(!soundEnabled);
 
-  return (
-    <div className="min-h-screen bg-background text-foreground">
-      <MenuAudioLoop />
-      <main className="container mx-auto flex min-h-screen flex-col items-center justify-center gap-16 px-4 py-16">
-        <h2 className="font-heading text-center text-7xl font-semibold tracking-widest">
-          Spooky <span className="text-secondary">Surprise</span>
-        </h2>
+    return (
+        <div className="min-h-screen bg-background text-foreground">
+            <MenuAudioLoop />
+            <main className="container mx-auto flex min-h-screen flex-col items-center justify-center gap-16 px-4 py-16">
+                <h2 className="font-heading text-center text-7xl font-semibold tracking-widest">
+                    Spooky <span className="text-secondary">Surprise</span>
+                </h2>
 
-        <div className="flex w-full max-w-3xl justify-center">
-          <Button
-            className="px-4 py-2 text-sm"
-            onClick={toggleSound}
-            aria-pressed={soundEnabled}
-          >
-            {soundEnabled ? 'Disable Sound' : 'Enable Sound'}
-          </Button>
+                <div className="flex w-full max-w-3xl justify-center">
+                    <Button
+                        className="px-4 py-2 text-sm"
+                        onClick={toggleSound}
+                        aria-pressed={soundEnabled}
+                    >
+                        {soundEnabled ? "Disable Sound" : "Enable Sound"}
+                    </Button>
+                </div>
+
+                <section className="w-full max-w-3xl">
+                    <StoryRenderer />
+                </section>
+
+                <section className="w-full max-w-3xl space-y-4 rounded-2xl border border-border/70 bg-surface/70 p-6 text-center shadow-inner">
+                    <div className="space-y-3">
+                        <p className="text-xs uppercase tracking-wide text-foreground/60">
+                            Current Location
+                        </p>
+                        <p className="font-heading text-3xl text-secondary">
+                            {currentNode}
+                        </p>
+                        <Button
+                            className="mt-4 w-full py-3 text-base"
+                            onClick={() => {
+                                reset();
+                                setPlayerName("");
+                            }}
+                        >
+                            Restart Adventure
+                        </Button>
+                    </div>
+
+                    <div className="space-y-3 text-left">
+                        <h3 className="font-heading text-lg uppercase tracking-wide text-foreground/70">
+                            Visited
+                        </h3>
+                        <p className="text-sm text-foreground/60">
+                            {visitedCount} locations explored
+                        </p>
+                        <ul className="grid gap-2 text-sm text-foreground/80 sm:grid-cols-2">
+                            {visited.map((nodeId) => (
+                                <li
+                                    key={nodeId}
+                                    className="rounded border border-border/50 bg-background/40 px-3 py-2"
+                                >
+                                    {nodeId}
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                </section>
+
+                <div className="mt-auto w-full pb-8 pt-12">
+                    <div className="flex justify-center gap-4">
+                        <Button onClick={() => setIsSettingsOpen(true)}>
+                            Settings
+                        </Button>
+                        <ThemeToggle />
+                    </div>
+                </div>
+            </main>
+
+            <SettingsMenu
+                isOpen={isSettingsOpen}
+                onClose={() => setIsSettingsOpen(false)}
+            />
         </div>
-
-        <section className="w-full max-w-3xl">
-          <StoryRenderer />
-        </section>
-
-        <section className="w-full max-w-3xl space-y-4 rounded-2xl border border-border/70 bg-surface/70 p-6 text-center shadow-inner">
-          <div className="space-y-3">
-            <p className="text-xs uppercase tracking-wide text-foreground/60">Current Location</p>
-            <p className="font-heading text-3xl text-secondary">{currentNode}</p>
-            <Button className="mt-2 w-full py-3 text-base" onClick={reset}>
-              Restart Adventure
-            </Button>
-          </div>
-
-          <div className="space-y-3 text-left">
-            <h3 className="font-heading text-lg uppercase tracking-wide text-foreground/70">Visited</h3>
-            <p className="text-sm text-foreground/60">{visitedCount} locations explored</p>
-            <ul className="grid gap-2 text-sm text-foreground/80 sm:grid-cols-2">
-              {visited.map((nodeId) => (
-                <li key={nodeId} className="rounded border border-border/50 bg-background/40 px-3 py-2">
-                  {nodeId}
-                </li>
-              ))}
-            </ul>
-          </div>
-
-        </section>
-
-        <div className="mt-auto w-full pb-8 pt-12">
-          <div className="flex justify-center gap-4">
-            <Button onClick={() => setIsSettingsOpen(true)}>
-              Settings
-            </Button>
-            <ThemeToggle />
-          </div>
-        </div>
-      </main>
-
-      <SettingsMenu isOpen={isSettingsOpen} onClose={() => setIsSettingsOpen(false)} />
-    </div>
-  )
+    );
 }
 
-export default App
+export default App;

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -1,90 +1,121 @@
-import { useMemo, useState } from 'react'
-import { storyNodes, type StoryNode } from '../data/storyNodes'
-import { useStoryStore } from '../store/storyStore'
-import { Button } from './ui/Button'
+import { useMemo, useState } from "react";
+import { storyNodes, type StoryNode } from "../data/storyNodes";
+import { useStoryStore } from "../store/storyStore";
+import { Button } from "./ui/Button";
+import { NameInput } from "./name";
 
 interface SceneProps {
-  node: StoryNode
+    node: StoryNode;
 }
 
 export default function Scene({ node }: SceneProps) {
-  const { setNode, recordRoll, lastRoll } = useStoryStore()
-  const [isRolling, setIsRolling] = useState(false)
+    const { setNode, recordRoll, lastRoll, playerName, setPlayerName } =
+        useStoryStore();
+    const [isRolling, setIsRolling] = useState(false);
 
-  const choices = useMemo(() => node.choices ?? [], [node.choices])
+    const choices = useMemo(() => node.choices ?? [], [node.choices]);
 
-  const handleChoice = (nextId: string) => {
-    if (!storyNodes[nextId]) {
-      return
-    }
-    setNode(nextId)
-  }
+    const handleChoice = (nextId: string) => {
+        if (!storyNodes[nextId]) return;
+        setNode(nextId);
+    };
 
-  const handleDiceRoll = () => {
-    if (!node.diceCheck || isRolling) {
-      return
-    }
+    const handleDiceRoll = () => {
+        if (!node.diceCheck || isRolling) return;
 
-    setIsRolling(true)
-    const roll = Math.ceil(Math.random() * 20)
-    recordRoll(roll)
+        setIsRolling(true);
+        const roll = Math.ceil(Math.random() * 20);
+        recordRoll(roll);
 
-    const result = roll >= node.diceCheck.target ? node.diceCheck.success : node.diceCheck.fail
+        const result =
+            roll >= node.diceCheck.target
+                ? node.diceCheck.success
+                : node.diceCheck.fail;
 
-    setTimeout(() => {
-      setIsRolling(false)
-      handleChoice(result)
-    }, 1100)
-  }
+        setTimeout(() => {
+            setIsRolling(false);
+            handleChoice(result);
+        }, 1100);
+    };
 
-  return (
-    <div className="w-full max-w-3xl space-y-6 rounded-2xl border border-border/60 bg-surface/80 p-8 shadow-lg shadow-primary/15">
-      <header className="space-y-2 text-center">
-        <h3 className="font-heading text-3xl font-semibold text-secondary">Chapter: {node.id}</h3>
-      </header>
+    const renderText = useMemo(() => {
+        if (typeof node.text === "function") return node.text(playerName);
+        return node.text.replaceAll("PLAYERNAME", playerName || "_____");
+    }, [node, playerName]);
 
-      <p className="text-lg leading-relaxed text-foreground/90">{node.text}</p>
+    return (
+        <div className="w-full max-w-3xl space-y-6 rounded-2xl border border-border/60 bg-surface/80 p-8 shadow-lg shadow-primary/15">
+            <header className="space-y-2 text-center">
+                <h3 className="font-heading text-3xl font-semibold text-secondary">
+                    Chapter: {node.id}
+                </h3>
+            </header>
 
-      {choices.length > 0 ? (
-        <div className="space-y-2">
-          <h4 className="font-heading text-lg uppercase tracking-wide text-foreground/80">Choices</h4>
-          <div className="grid gap-3 sm:grid-cols-2">
-            {choices.map((choice) => (
-              <Button
-                key={`${node.id}-${choice.next}-${choice.text}`}
-                className="h-auto justify-start whitespace-normal py-3 text-left leading-relaxed"
-                onClick={() => handleChoice(choice.next)}
-              >
-                {choice.text}
-              </Button>
-            ))}
-          </div>
+            <p className="text-lg leading-relaxed text-foreground/90">
+                {renderText}
+                {node.requiresName && (
+                    <>
+                        {" "}
+                        <NameInput
+                            playerName={playerName}
+                            setPlayerName={setPlayerName}
+                        />
+                    </>
+                )}
+            </p>
+
+            {/* ✅ Choices */}
+            {choices.length > 0 ? (
+                <div className="space-y-2">
+                    <h4 className="font-heading text-lg uppercase tracking-wide text-foreground/80">
+                        Choices
+                    </h4>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        {choices.map((choice) => (
+                            <Button
+                                key={`${node.id}-${choice.next}-${choice.text}`}
+                                className="h-auto justify-start whitespace-normal py-3 text-left leading-relaxed"
+                                onClick={() => handleChoice(choice.next)}
+                                disabled={node.requiresName && !playerName}
+                            >
+                                {choice.text}
+                            </Button>
+                        ))}
+                    </div>
+                </div>
+            ) : !node.diceCheck ? (
+                <p className="rounded-lg border border-border/40 bg-background/60 p-4 text-center text-sm text-foreground/70">
+                    No choices remain here. Perhaps another path will reveal
+                    itself later.
+                </p>
+            ) : null}
+
+            {/* ✅ Dice check block */}
+            {node.diceCheck && (
+                <div className="space-y-3 rounded-xl border border-border/40 bg-background/60 p-4">
+                    <p className="text-sm text-foreground/80">
+                        Roll for{" "}
+                        <span className="font-semibold uppercase">
+                            {node.diceCheck.stat}
+                        </span>{" "}
+                        — target {node.diceCheck.target}
+                    </p>
+                    <Button
+                        className="w-full py-3 text-base font-semibold"
+                        onClick={handleDiceRoll}
+                        disabled={isRolling}
+                    >
+                        {isRolling ? "Rolling..." : "Roll the Dice"}
+                    </Button>
+                </div>
+            )}
+
+            {/* ✅ Display roll result */}
+            {lastRoll !== null && (
+                <p className="text-center text-sm text-foreground/70">
+                    You rolled a {lastRoll}.
+                </p>
+            )}
         </div>
-      ) : !node.diceCheck ? (
-        <p className="rounded-lg border border-border/40 bg-background/60 p-4 text-center text-sm text-foreground/70">
-          No choices remain here. Perhaps another path will reveal itself later.
-        </p>
-      ) : null}
-
-      {node.diceCheck ? (
-        <div className="space-y-3 rounded-xl border border-border/40 bg-background/60 p-4">
-          <p className="text-sm text-foreground/80">
-            Roll for <span className="font-semibold uppercase">{node.diceCheck.stat}</span> — target{' '}
-            {node.diceCheck.target}
-          </p>
-          <Button
-            className="w-full py-3 text-base font-semibold"
-            onClick={handleDiceRoll}
-            disabled={isRolling}
-          >
-            {isRolling ? 'Rolling...' : 'Roll the Dice'}
-          </Button>
-        </div>
-      ) : null}
-
-      {lastRoll !== null ? (
-        <p className="text-center text-sm text-foreground/70">You rolled a {lastRoll}.</p>
-      ) : null}
-    </div>
-  )
+    );
 }

--- a/src/components/name.tsx
+++ b/src/components/name.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+
+interface NameInputProps {
+    playerName: string;
+    setPlayerName: (name: string) => void;
+}
+
+export const NameInput: React.FC<NameInputProps> = ({
+    playerName,
+    setPlayerName,
+}) => {
+    const [tempName, setTempName] = useState(playerName);
+    const [confirmed, setConfirmed] = useState(!!playerName);
+
+    const handleConfirm = () => {
+        if (!tempName.trim()) return; // ignore blank
+        setPlayerName(tempName.trim());
+        setConfirmed(true);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === "Enter") handleConfirm();
+    };
+
+    if (confirmed) {
+        return <strong className="ml-2 text-secondary">{playerName}</strong>;
+    }
+
+    return (
+        <span className="inline-name-input flex items-center gap-2 mt-2">
+            <input
+                type="text"
+                placeholder="Your name, Brichan?"
+                value={tempName}
+                onChange={(e) => setTempName(e.target.value)}
+                onKeyDown={handleKeyDown}
+                className="bg-transparent border-b border-gray-400 text-white px-2 focus:outline-none"
+            />
+            <button
+                type="button"
+                onClick={handleConfirm}
+                className="text-sm text-gray-300 hover:text-white transition-colors"
+            >
+                Confirm
+            </button>
+        </span>
+    );
+};

--- a/src/data/storyNodes.ts
+++ b/src/data/storyNodes.ts
@@ -1,137 +1,167 @@
 export interface StoryChoice {
-  text: string
-  next: string
+    text: string;
+    next: string;
 }
 
 export interface StoryNode {
-  id: string
-  text: string
-  choices?: StoryChoice[]
-  diceCheck?: {
-    stat: string
-    target: number
-    success: string
-    fail: string
-  }
+    id: string;
+    text: string | ((playerName: string) => string);
+    choices?: StoryChoice[];
+    diceCheck?: {
+        stat: string;
+        target: number;
+        success: string;
+        fail: string;
+    };
+    requiresName?: boolean;
 }
 
 export const storyNodes: Record<string, StoryNode> = {
-  intro: {
-    id: 'intro',
-    text:
-      'You wake to the creak of settling stone. The chapel breathes--a long, slow inhale as dust drifts through angled light. Moss has claimed the pews; candles gutter in half-melted sconces, their flames trembling as the dimensions slide into alignment. Your skin hums with black-gold veins, the heartbeat of the Veil answering your own. Through shattered lenses you glimpse echoes of other Brichan, their silhouettes caught in flame like prayers that refuse to die. The Hunt has begun again.',
-    choices: [
-      { text: 'Draw the lenses from their satchel and stand', next: 'foyer' },
-      { text: 'Listen to the whispers behind the walls', next: 'moonlitPath' },
-    ],
-  },
-  foyer: {
-    id: 'foyer',
-    text:
-      'The narthex smells of cold wax and old smoke. Mirrors line the stone pillars, angled to catch the light of absent pyres. Each mirror bears the scorch mark of a Brichan lens--rings of gold, blue, and violet burned deep into the glass. Something here has already anchored: a presence tugging at the edges of the Veil.',
-    choices: [
-      { text: 'Align the lenses and sweep for the anchor', next: 'secretPassage' },
-      { text: 'Call to the ghosts of former hunters', next: 'whisper' },
-    ],
-  },
-  moonlitPath: {
-    id: 'moonlitPath',
-    text:
-      'You linger in the chapel hush and let the whispers rise. They speak of Alderthorn\'s fields, of pyres that once blazed across the harvest. Outside the stained glass, the night bleeds through--the Veil is thin here, and the hell-ridden landscape presses in with hungry patience.',
-    choices: [
-      { text: 'Answer the whispers and bargain for knowledge', next: 'lantern' },
-      { text: 'Shake free of the voices and refocus', next: 'intro' },
-    ],
-  },
-  secretPassage: {
-    id: 'secretPassage',
-    text:
-      'The aligned lenses flare. Neamh burns bright, Muir ripples, and Talamh drinks in the dark. A stained altar cracks open, revealing a stair that descends into the ossuary beneath. The corruption recoils, but it clings to something below.',
-    diceCheck: {
-      stat: 'fortitude',
-      target: 12,
-      success: 'cellar',
-      fail: 'panic',
+    Neamh: {
+        id: "Prologue 1 - The Chapel",
+        text: "You wake to the creak of settling stone. The chapel breathes — a long, slow inhale as dust drifts through angled light. Moss has claimed the pews; candles gutter in half-melted sconces, their flames trembling as the dimensions slide into alignment.",
+        choices: [
+            {
+                text: "Gather yourself and inhale the quiet",
+                next: "Muir",
+            },
+        ],
     },
-  },
-  panic: {
-    id: 'panic',
-    text:
-      'The lens flares sear across your palm. The veins beneath your skin blaze too hot, and the corruption surges toward your heart. You stagger back, the stair sealing with a slam. You cannot descend until you master the burning light.',
-    choices: [{ text: 'Steady your breath and survey the narthex once more', next: 'foyer' }],
-  },
-  cellar: {
-    id: 'cellar',
-    text:
-      'Bones of alder roots twist through the ceiling, dripping with crimson resin. The air is wet and electric. An anchor hangs above a pyre basin: a tarnished censer, pulsing with stolen breaths. Spirits circle it like moths to a wound.',
-    choices: [
-      { text: 'Focus the lenses on the censer', next: 'amulet' },
-      { text: 'Retreat and regroup before confronting it', next: 'foyer' },
-    ],
-  },
-  amulet: {
-    id: 'amulet',
-    text:
-      'Neamh strikes first, searing the outer shell. Muir follows, revealing faces trapped within the smoke. Talamh clamps shut, devouring the corruption and channeling it into your veins. It leaves behind a shard of tempered glass etched with the three rings--a token of service and a warning of your limits.',
-    choices: [{ text: 'Absorb the shard and prepare to ascend', next: 'cellarReturn' }],
-  },
-  cellarReturn: {
-    id: 'cellarReturn',
-    text:
-      'The censer is silent, yet the shard hums in your grasp. Each pulse tightens the web of dark lines beneath your skin. Above, the chapel waits with more anchors to break.',
-    choices: [{ text: 'Return to the narthex', next: 'foyer' }],
-  },
-  whisper: {
-    id: 'whisper',
-    text:
-      'Your voice echoes through the vaulted ceiling, and the answer comes at once: a chorus of former Brichan, their words carried on candle smoke. "Neamh begins. Muir reveals. Talamh ends. Remember the order or be devoured." A final whisper adds, almost kindly, "The lens remembers your first failure."',
-    choices: [
-      { text: 'Sprint toward the bell tower to confront the echo', next: 'staircase' },
-      { text: 'Bow in thanks and steady your focus', next: 'intro' },
-    ],
-  },
-  staircase: {
-    id: 'staircase',
-    text:
-      'You ascend the spiral stairs, mirrors flashing with fragments of other worlds. At the top stands the bell tower door, sealed by strands of shadow silk. The corruption here is clever, mimicking the motions of the lens.',
-    diceCheck: {
-      stat: 'insight',
-      target: 14,
-      success: 'moonDoor',
-      fail: 'soulLock',
+    Muir: {
+        id: "Prologue 2 - Their Name",
+        text: "You stand in the hush between worlds, memory hanging just out of reach. The voice that calls you isn’t from above or below — it comes from within, threaded through the pulse of light under your skin. You remember the creed, the burden, the endless hunt… but not your name. That part was left behind in the last turning of the Veil. The world will not know you until you speak it again. Who are you, Brichan?",
+        requiresName: true,
+        choices: [
+            {
+                text: "Align the lenses and sweep for the anchor",
+                next: "Talamh",
+            },
+        ],
     },
-  },
-  moonDoor: {
-    id: 'moonDoor',
-    text:
-      'You align the rings in perfect rhythm. Neamh, Muir, Talamh. The strands shriek and dissolve, revealing a bell chamber washed in lunar light. An altar holds a ledger of Brichan vows, and beside it lies a mirror draped in pyre ash.',
-    choices: [{ text: 'Read the ledger and heed its warning', next: 'study' }],
-  },
-  soulLock: {
-    id: 'soulLock',
-    text:
-      'The strands lash your arm. The corruption flares past your control, and for a heartbeat you see the hellscape pressing against Alderthorn--a sky of teeth, a field of broken mirrors. The door seals, saving you from being pulled across the Veil.',
-    choices: [{ text: 'Retreat before the corruption consumes you', next: 'foyer' }],
-  },
-  study: {
-    id: 'study',
-    text:
-      'The ledger lists names burned away by duty. Margins describe the lens rings: Neamh the Breath of Heaven, Muir the Mirror Sea, Talamh the Root Flame. A final entry speaks of a lantern forged from three mirrors--your next anchor to sever.',
-    choices: [{ text: 'Follow the ledger\'s guidance toward the garden pyres', next: 'lantern' }],
-  },
-  lantern: {
-    id: 'lantern',
-    text:
-      'In the garden cloister, a lantern formed of concentric mirrors floats above a cold brazier. Pyre mirrors around it have gone dark--no candles remain to hold the Veil at bay. The lantern flickers with stolen souls.',
-    choices: [
-      { text: 'Align the lenses and draw the corruption into yourself', next: 'lanternTaken' },
-      { text: 'Step away and let the lantern hang for now', next: 'intro' },
-    ],
-  },
-  lanternTaken: {
-    id: 'lanternTaken',
-    text:
-      'The three rings harmonize. Neamh blazes, Muir reveals the faces trapped within, and Talamh devours the remainder. The lantern collapses into a single ember that brands your palm. Alderthorn is safer--for this night. The veins beneath your skin darken, a reminder of how close you stand to the abyss.',
-    choices: [{ text: 'Let the ember guide you back inside', next: 'foyer' }],
-  },
-}
+    Talamh: {
+        id: "moonlitPath",
+        text: "The whisper fades, I am PLAYERNAME, leaving only the sound of stone settling and the pulse in your veins. Something tugs at you — faint, magnetic, inevitable. Beneath the altar, half-buried in moss and wax, lies the shape you’ve known longer than your own face.",
+        choices: [
+            {
+                text: "Answer the whispers and bargain for knowledge",
+                next: "lantern",
+            },
+            { text: "Shake free of the voices and refocus", next: "intro" },
+        ],
+    },
+    secretPassage: {
+        id: "secretPassage",
+        text: "The aligned lenses flare. Neamh burns bright, Muir ripples, and Talamh drinks in the dark. A stained altar cracks open, revealing a stair that descends into the ossuary beneath. The corruption recoils, but it clings to something below.",
+        diceCheck: {
+            stat: "fortitude",
+            target: 12,
+            success: "cellar",
+            fail: "panic",
+        },
+    },
+    panic: {
+        id: "panic",
+        text: "The lens flares sear across your palm. The veins beneath your skin blaze too hot, and the corruption surges toward your heart. You stagger back, the stair sealing with a slam. You cannot descend until you master the burning light.",
+        choices: [
+            {
+                text: "Steady your breath and survey the narthex once more",
+                next: "foyer",
+            },
+        ],
+    },
+    cellar: {
+        id: "cellar",
+        text: "Bones of alder roots twist through the ceiling, dripping with crimson resin. The air is wet and electric. An anchor hangs above a pyre basin: a tarnished censer, pulsing with stolen breaths. Spirits circle it like moths to a wound.",
+        choices: [
+            { text: "Focus the lenses on the censer", next: "amulet" },
+            {
+                text: "Retreat and regroup before confronting it",
+                next: "foyer",
+            },
+        ],
+    },
+    amulet: {
+        id: "amulet",
+        text: "Neamh strikes first, searing the outer shell. Muir follows, revealing faces trapped within the smoke. Talamh clamps shut, devouring the corruption and channeling it into your veins. It leaves behind a shard of tempered glass etched with the three rings--a token of service and a warning of your limits.",
+        choices: [
+            {
+                text: "Absorb the shard and prepare to ascend",
+                next: "cellarReturn",
+            },
+        ],
+    },
+    cellarReturn: {
+        id: "cellarReturn",
+        text: "The censer is silent, yet the shard hums in your grasp. Each pulse tightens the web of dark lines beneath your skin. Above, the chapel waits with more anchors to break.",
+        choices: [{ text: "Return to the narthex", next: "foyer" }],
+    },
+    whisper: {
+        id: "whisper",
+        text: 'Your voice echoes through the vaulted ceiling, and the answer comes at once: a chorus of former Brichan, their words carried on candle smoke. "Neamh begins. Muir reveals. Talamh ends. Remember the order or be devoured." A final whisper adds, almost kindly, "The lens remembers your first failure."',
+        choices: [
+            {
+                text: "Sprint toward the bell tower to confront the echo",
+                next: "staircase",
+            },
+            { text: "Bow in thanks and steady your focus", next: "intro" },
+        ],
+    },
+    staircase: {
+        id: "staircase",
+        text: "You ascend the spiral stairs, mirrors flashing with fragments of other worlds. At the top stands the bell tower door, sealed by strands of shadow silk. The corruption here is clever, mimicking the motions of the lens.",
+        diceCheck: {
+            stat: "insight",
+            target: 14,
+            success: "moonDoor",
+            fail: "soulLock",
+        },
+    },
+    moonDoor: {
+        id: "moonDoor",
+        text: "You align the rings in perfect rhythm. Neamh, Muir, Talamh. The strands shriek and dissolve, revealing a bell chamber washed in lunar light. An altar holds a ledger of Brichan vows, and beside it lies a mirror draped in pyre ash.",
+        choices: [
+            { text: "Read the ledger and heed its warning", next: "study" },
+        ],
+    },
+    soulLock: {
+        id: "soulLock",
+        text: "The strands lash your arm. The corruption flares past your control, and for a heartbeat you see the hellscape pressing against Alderthorn--a sky of teeth, a field of broken mirrors. The door seals, saving you from being pulled across the Veil.",
+        choices: [
+            {
+                text: "Retreat before the corruption consumes you",
+                next: "foyer",
+            },
+        ],
+    },
+    study: {
+        id: "study",
+        text: "The ledger lists names burned away by duty. Margins describe the lens rings: Neamh the Breath of Heaven, Muir the Mirror Sea, Talamh the Root Flame. A final entry speaks of a lantern forged from three mirrors--your next anchor to sever.",
+        choices: [
+            {
+                text: "Follow the ledger's guidance toward the garden pyres",
+                next: "lantern",
+            },
+        ],
+    },
+    lantern: {
+        id: "lantern",
+        text: "In the garden cloister, a lantern formed of concentric mirrors floats above a cold brazier. Pyre mirrors around it have gone dark--no candles remain to hold the Veil at bay. The lantern flickers with stolen souls.",
+        choices: [
+            {
+                text: "Align the lenses and draw the corruption into yourself",
+                next: "lanternTaken",
+            },
+            {
+                text: "Step away and let the lantern hang for now",
+                next: "intro",
+            },
+        ],
+    },
+    lanternTaken: {
+        id: "lanternTaken",
+        text: "The three rings harmonize. Neamh blazes, Muir reveals the faces trapped within, and Talamh devours the remainder. The lantern collapses into a single ember that brands your palm. Alderthorn is safer--for this night. The veins beneath your skin darken, a reminder of how close you stand to the abyss.",
+        choices: [
+            { text: "Let the ember guide you back inside", next: "foyer" },
+        ],
+    },
+};

--- a/src/store/storyStore.ts
+++ b/src/store/storyStore.ts
@@ -1,54 +1,60 @@
-import { create } from 'zustand'
-import { storyNodes } from '../data/storyNodes'
+import { create } from "zustand";
+import { storyNodes } from "../data/storyNodes";
 
 const getInitialSoundEnabled = () => {
-  if (typeof window === 'undefined') {
-    return false
-  }
-  const stored = window.localStorage.getItem('soundEnabled')
-  return stored !== null ? stored === 'true' : false
-}
+    if (typeof window === "undefined") {
+        return false;
+    }
+    const stored = window.localStorage.getItem("soundEnabled");
+    return stored !== null ? stored === "true" : false;
+};
 
 interface StoryState {
-  currentNode: string
-  visited: string[]
-  lastRoll: number | null
-  soundEnabled: boolean
-  setNode: (id: string) => void
-  recordRoll: (value: number | null) => void
-  reset: () => void
-  setSoundEnabled: (value: boolean) => void
+    currentNode: string;
+    visited: string[];
+    lastRoll: number | null;
+    soundEnabled: boolean;
+    setNode: (id: string) => void;
+    recordRoll: (value: number | null) => void;
+    reset: () => void;
+    setSoundEnabled: (value: boolean) => void;
+    playerName: string;
+    setPlayerName: (name: string) => void;
 }
 
 export const useStoryStore = create<StoryState>((set) => ({
-  currentNode: 'intro',
-  visited: ['intro'],
-  lastRoll: null,
-  soundEnabled: getInitialSoundEnabled(),
-  setNode: (id) =>
-    set((state) => ({
-      currentNode: storyNodes[id] ? id : state.currentNode,
-      visited: state.visited.includes(id) ? state.visited : [...state.visited, id],
-      lastRoll: null,
-    })),
-  recordRoll: (value) =>
-    set(() => ({
-      lastRoll: value,
-    })),
-  reset: () =>
-    set((state) => ({
-      currentNode: 'intro',
-      visited: ['intro'],
-      lastRoll: null,
-      soundEnabled: state.soundEnabled,
-    })),
-  setSoundEnabled: (value) =>
-    set(() => {
-      if (typeof window !== 'undefined') {
-        window.localStorage.setItem('soundEnabled', String(value))
-      }
-      return {
-        soundEnabled: value,
-      }
-    }),
-}))
+    currentNode: "Neamh",
+    visited: ["Neamh"],
+    lastRoll: null,
+    soundEnabled: getInitialSoundEnabled(),
+    playerName: "",
+    setPlayerName: (name) => set({ playerName: name }),
+    setNode: (id) =>
+        set((state) => ({
+            currentNode: storyNodes[id] ? id : state.currentNode,
+            visited: state.visited.includes(id)
+                ? state.visited
+                : [...state.visited, id],
+            lastRoll: null,
+        })),
+    recordRoll: (value) =>
+        set(() => ({
+            lastRoll: value,
+        })),
+    reset: () =>
+        set((state) => ({
+            currentNode: "Neamh",
+            visited: ["Neamh"],
+            lastRoll: null,
+            soundEnabled: state.soundEnabled,
+        })),
+    setSoundEnabled: (value) =>
+        set(() => {
+            if (typeof window !== "undefined") {
+                window.localStorage.setItem("soundEnabled", String(value));
+            }
+            return {
+                soundEnabled: value,
+            };
+        }),
+}));


### PR DESCRIPTION
Changes
This pull request introduces support for a player name input throughout the interactive story application. The main changes include adding a `NameInput` component, updating the story rendering logic to handle player names, and resetting the player name when restarting the adventure. Additionally, code formatting has been standardized across modified files.

Player name support:

* Added a new `NameInput` component (`src/components/name.tsx`) that allows users to enter and confirm their player name, which is then used throughout the story.
* Updated `Scene` component to render the `NameInput` when a story node requires a name, and to replace "PLAYERNAME" in the story text with the entered player name. Choices are now disabled until a name is entered if required.

Story state management:

* Modified the `App` component so that when the "Restart Adventure" button is clicked, the player name is also reset in addition to the story state.

Content:

Added first few story modules, will work the rest out tomorrow.

edit: whenever the use of PLAYERNAME is in the text string it will insert the players name